### PR TITLE
chore: remove git.io

### DIFF
--- a/info.py
+++ b/info.py
@@ -5,6 +5,6 @@ version = '3.0.0.0b0'
 channel = 'cloud'
 
 developer_id = 345060487
-repo = 'https://git.io/JvDw4'
+repo = 'https://github.com/KumaTea/Dragalia-bot'
 
 player_group = -1001157490282  # @dragaliazh


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022.

- https://github.blog/changelog/2022-04-25-git-io-deprecation/